### PR TITLE
Update install.sh to place pods-compose.ini in /etc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,5 +3,8 @@
 service="pods-compose.service"
 
 cp -v systemd/${service} /etc/systemd/system/
-cp -v pods-compose.ini /usr/local/bin/
+mkdir -p /etc/pdds-compose
+cp -v pods-compose.ini /etc/pods-compose
+echo "Default pods-compose.ini placed in /etc/pods-compose."
+echo "Per-user settings can be placed in $HOME/.pods-compose.ini 
 cp -v pods-compose.py /usr/local/bin/pods-compose


### PR DESCRIPTION
If you accept the pull request allowing for different locations for pods-compose.ini, this patch changes the default location for pods-compose.ini to /etc/pods-compose/pods-compose.ini.